### PR TITLE
홈스크린의 인증버튼 및 모달 컴포넌트화

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,9 +82,9 @@ android {
         applicationId "com.jandit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 7
+        versionCode 8
         multiDexEnabled true
-        versionName "1.0.6"
+        versionName "1.0.7"
     }
     signingConfigs {
         debug {

--- a/src/components/AuthButtons/AuthButtonStyles.ts
+++ b/src/components/AuthButtons/AuthButtonStyles.ts
@@ -1,0 +1,11 @@
+import {StyleSheet, Dimensions} from 'react-native';
+const {width, height} = Dimensions.get('window');
+
+export const AuthButtonStyles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: width * 0.05,
+    marginVertical: height * 0.05,
+  },
+});

--- a/src/components/AuthButtons/GroupAuthButton/GroupAuth.ts
+++ b/src/components/AuthButtons/GroupAuthButton/GroupAuth.ts
@@ -1,0 +1,30 @@
+import {StyleSheet, Dimensions} from 'react-native';
+const {width, height} = Dimensions.get('window');
+
+export const GroupAuthStyles = StyleSheet.create({
+  button: {
+    width: width * 0.4,
+    height: height * 0.15,
+    justifyContent: 'center',
+    borderRadius: 8,
+    shadowColor: '#000',
+    alignItems: 'center',
+    backgroundColor: '#2C74A2',
+  },
+  icon: {
+    width: width * 0.3,
+    height: height * 0.08,
+    resizeMode: 'contain',
+    marginTop: 5,
+    marginLeft: 60,
+  },
+  text: {
+    marginTop: -50,
+    marginLeft: 24,
+    width: width * 0.5,
+    color: '#fff',
+    fontSize: width * 0.04,
+    fontWeight: 'bold',
+    fontFamily: 'NanumSquareNeo-Variable',
+  },
+});

--- a/src/components/AuthButtons/GroupAuthButton/index.tsx
+++ b/src/components/AuthButtons/GroupAuthButton/index.tsx
@@ -1,59 +1,39 @@
 import {Button, ButtonText, ButtonIcon} from '@/components/ui/button';
 import React, {useState} from 'react';
-import {Image, Dimensions} from 'react-native';
-
-const {width, height} = Dimensions.get('window');
+import {Image} from 'react-native';
+import UpcomingModal from '../../Modal/UpcomingModal';
+import {GroupAuthStyles} from './GroupAuth';
 const IMAGES = {
-  self: require('../../../../assets/images/illustration/typeTwo.png'),
   together: require('../../../../assets/images/illustration/typeOne.png'),
 };
 
 const GroupAuth = () => {
-  const [modalVisible, setModalVisible] = useState(false);
-  const [modalMessage, setModalMessage] = useState('');
-  const handleNotUseableModal = () => {
-    setModalMessage('추가 예정인 기능입니다.111');
-    console.log(modalMessage);
-    setModalVisible(true);
-    return;
+  const [showModal, setShowModal] = useState(false);
+  const handleModalOpen = () => {
+    setShowModal(true);
   };
 
   return (
-    <Button
-      className="bg-primary rounded-lg shadow-lg"
-      variant="solid"
-      action="primary"
-      style={{
-        width: width * 0.4,
-        height: height * 0.15,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#1AA5AA',
-      }}
-      onPress={handleNotUseableModal}
-      T>
-      <ButtonIcon>
-        <Image
-          source={IMAGES.together}
-          style={{
-            width: width * 0.3,
-            height: height * 0.08,
-            resizeMode: 'contain',
-            marginTop: 10,
-          }}
-        />
-      </ButtonIcon>
-      <ButtonText
-        style={{
-          marginTop: 10,
-          color: '#fff',
-          fontSize: width * 0.04,
-          fontWeight: 'bold',
-          fontFamily: 'NanumSquareNeo-Variable',
-        }}>
-        함께 인증하기
-      </ButtonText>
-    </Button>
+    <>
+      <Button
+        className="active:opacity-80 active:scale-95"
+        variant="solid"
+        action="primary"
+        style={GroupAuthStyles.button}
+        onPress={handleModalOpen}>
+        <ButtonIcon>
+          <Image source={IMAGES.together} style={GroupAuthStyles.icon} />
+        </ButtonIcon>
+        <ButtonText style={GroupAuthStyles.text}>
+          랜덤 스터디 매칭하기
+        </ButtonText>
+      </Button>
+      <UpcomingModal
+        showModal={showModal}
+        setShowModal={setShowModal}
+        text="추가 예정 기능입니다."
+      />
+    </>
   );
 };
 

--- a/src/components/AuthButtons/SingleAuthButton/SingleAuth.ts
+++ b/src/components/AuthButtons/SingleAuthButton/SingleAuth.ts
@@ -1,0 +1,29 @@
+import {StyleSheet, Dimensions} from 'react-native';
+const {width, height} = Dimensions.get('window');
+
+export const SingleAuthStyles = StyleSheet.create({
+  button: {
+    width: width * 0.4,
+    height: height * 0.15,
+    borderRadius: 8,
+    shadowColor: '#000',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#86C0AE',
+  },
+  icon: {
+    width: width * 0.3,
+    height: height * 0.08,
+    resizeMode: 'contain',
+    marginTop: 5,
+    marginLeft: 8,
+  },
+  text: {
+    marginTop: -50,
+    marginRight: 18,
+    color: '#fff',
+    fontSize: width * 0.04,
+    fontWeight: 'bold',
+    fontFamily: 'NanumSquareNeo-Variable',
+  },
+});

--- a/src/components/AuthButtons/SingleAuthButton/index.tsx
+++ b/src/components/AuthButtons/SingleAuthButton/index.tsx
@@ -1,0 +1,32 @@
+import {Button, ButtonText, ButtonIcon} from '@/components/ui/button';
+import React, {useState} from 'react';
+import {Image} from 'react-native';
+import LocationModal from '../../Modal/LocationModal';
+import {SingleAuthStyles} from './SingleAuth';
+const IMAGES = {
+  self: require('../../../../assets/images/illustration/typeTwo.png'),
+};
+
+const SingleAuth = () => {
+  const [showModal, setShowModal] = useState(false);
+  const handleModalOpen = () => {
+    setShowModal(true);
+  };
+
+  return (
+    <>
+      <Button
+        className="active:opacity-80 active:scale-95"
+        style={SingleAuthStyles.button}
+        onPress={handleModalOpen}>
+        <ButtonIcon>
+          <Image source={IMAGES.self} style={SingleAuthStyles.icon} />
+        </ButtonIcon>
+        <ButtonText style={SingleAuthStyles.text}>혼자 인증하기</ButtonText>
+      </Button>
+      <LocationModal showModal={showModal} setShowModal={setShowModal} />
+    </>
+  );
+};
+
+export default SingleAuth;

--- a/src/components/AuthButtons/index.tsx
+++ b/src/components/AuthButtons/index.tsx
@@ -1,17 +1,14 @@
 import {Box} from '@/components/ui/box';
 import GroupAuth from './GroupAuthButton';
-import {Dimensions} from 'react-native';
+import SingleAuth from './SingleAuthButton';
 import React from 'react';
-const {width, height} = Dimensions.get('window');
+import {AuthButtonStyles} from './AuthButtonStyles';
+
 const AuthButtons = () => {
   return (
-    <Box
-      className="flex-row justify-between"
-      style={{
-        paddingHorizontal: width * 0.05,
-        marginVertical: height * 0.05,
-      }}>
+    <Box style={AuthButtonStyles.container}>
       <GroupAuth />
+      <SingleAuth />
     </Box>
   );
 };

--- a/src/components/Modal/LocationModal.tsx
+++ b/src/components/Modal/LocationModal.tsx
@@ -1,0 +1,22 @@
+import React, {useState} from 'react';
+import UpcomingModal from './UpcomingModal';
+
+type LocationModalProps = {
+  showModal: boolean;
+  setShowModal: (value: boolean) => void;
+};
+
+const LocationModal: React.FC<LocationModalProps> = ({
+  showModal,
+  setShowModal,
+}) => {
+  return (
+    <UpcomingModal
+      showModal={showModal}
+      setShowModal={setShowModal}
+      text="위치 권한이 필요합니다."
+    />
+  );
+};
+
+export default LocationModal;

--- a/src/components/Modal/UpcomingModal.tsx
+++ b/src/components/Modal/UpcomingModal.tsx
@@ -1,0 +1,45 @@
+import {
+  Modal,
+  ModalBackdrop,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+} from '@/components/ui/modal';
+import {Text} from 'react-native';
+import React from 'react';
+import {UpcomingModalStyles} from './UpcomingModalStyle';
+
+type UpcomingModalProps = {
+  showModal: boolean;
+  setShowModal: (value: boolean) => void;
+  text: string;
+};
+
+const UpcomingModal: React.FC<UpcomingModalProps> = ({
+  showModal,
+  setShowModal,
+  text,
+}) => {
+  return (
+    <Modal
+      isOpen={showModal}
+      onClose={() => {
+        setShowModal(false);
+      }}>
+      <ModalBackdrop />
+      <ModalContent style={UpcomingModalStyles.modalContent}>
+        <ModalBody>
+          <Text style={UpcomingModalStyles.modalText}>{text}</Text>
+        </ModalBody>
+        <ModalFooter>
+          <ModalCloseButton style={UpcomingModalStyles.closeButton}>
+            <Text style={UpcomingModalStyles.closeButtonText}>닫기</Text>
+          </ModalCloseButton>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default UpcomingModal;

--- a/src/components/Modal/UpcomingModalStyle.ts
+++ b/src/components/Modal/UpcomingModalStyle.ts
@@ -1,0 +1,40 @@
+import {StyleSheet, Dimensions} from 'react-native';
+const {width, height} = Dimensions.get('window');
+
+export const UpcomingModalStyles = StyleSheet.create({
+  modalContent: {
+    width: width * 0.8,
+    maxHeight: height * 0.6,
+    backgroundColor: 'white',
+    borderRadius: 8,
+    padding: width * 0.05,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  modalText: {
+    marginBottom: height * 0.02,
+    textAlign: 'left',
+    fontSize: width * 0.04,
+    fontWeight: '700',
+    fontFamily: 'NanumSquareNeo-Variable',
+    color: '#000000',
+  },
+  closeButton: {
+    backgroundColor: '#1AA5AA',
+    borderRadius: 4,
+    paddingVertical: height * 0.015,
+    paddingHorizontal: width * 0.1,
+  },
+  closeButtonText: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: width * 0.035,
+  },
+});


### PR DESCRIPTION
## 💡 Issue number (#6)
https://github.com/su-yeong-ice-pork/front-end/issues/6

## 🚀 Description
gluestack-ui 도입하여 HomeScreen의 인증 버튼들을 컴포넌트화 하였다.
Component 폴더에 AuthButtons와 Modal 폴더 생성 하였다.
style.ts를 분리하여 스타일 설정 하였다.
기능 추가 예정 모달과 위치인증 모달을 컴포넌트화 하였다.

## 💻 etc.

close #6 