### PR TITLE
[FEATURE] 스터디 방 생성 API 구현

### DIFF
--- a/src/api/study/studies/createStudy.ts
+++ b/src/api/study/studies/createStudy.ts
@@ -1,0 +1,26 @@
+import apiClient from '@/src/api/axiosInstance';
+import {AxiosResponse} from 'axios';
+import {CreateStudyRequest, CreateStudyResponse} from '../types';
+
+/**
+ * POST /regular-studies API 호출
+ * @param newStudy 생성할 스터디 정보
+ * @param authToken 인증 토큰
+ * @returns 응답의 response 객체
+ */
+export const createStudy = async (
+  newStudy: CreateStudyRequest,
+  authToken: string,
+): Promise<{inviteCode: string}> => {
+  const response: AxiosResponse<CreateStudyResponse> = await apiClient.post(
+    '/regular-studies',
+    newStudy,
+    {
+      headers: {Authorization: authToken},
+    },
+  );
+  if (!response.data.success) {
+    throw new Error(response.data.error || '스터디 생성에 실패했습니다.');
+  }
+  return response.data.response;
+};

--- a/src/api/study/types.ts
+++ b/src/api/study/types.ts
@@ -44,3 +44,17 @@ export type GetStudyParticipantsResponse = {
   };
   error: string | null;
 };
+
+export type CreateStudyRequest = {
+  name: string;
+  goalMessage: string;
+  goalTime: number;
+};
+
+export type CreateStudyResponse = {
+  success: boolean;
+  response: {
+    inviteCode: string;
+  };
+  error: string | null;
+};

--- a/src/components/CreateStudyForm/index.tsx
+++ b/src/components/CreateStudyForm/index.tsx
@@ -1,44 +1,25 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {VStack} from '@/components/ui';
 import CreateStudyInputField from '@/src/components/CreateStudyForm/InputField';
 import {ICONS} from '@/src/constants/image/icons';
-import {CREATE_FORM} from '@/src/constants/CreateStudy/createStudy.ts';
-import {CreateStudyFormStyles} from '@/src/components/CreateStudyForm/CreateStudyFormStyles.ts';
+import {CREATE_FORM} from '@/src/constants/CreateStudy/createStudy';
+import {CreateStudyFormStyles} from '@/src/components/CreateStudyForm/CreateStudyFormStyles';
 import SubmitButton from '@/src/components/CreateStudyForm/SubmitButton';
 import Introduction from '@/src/components/CreateStudyForm/Introduction';
-import {Text} from 'react-native';
+import {useCreateStudyForm} from '@/src/hooks/useCreateStudyForm';
 
-const CreateStudyForm = ({}) => {
-  const [name, setName] = useState('');
-  const [goalMessage, setGoalMessage] = useState('');
-  const [goalTime, setGoalTime] = useState('');
-  const [parsedGoalTime, setParsedGoalTime] = useState(0);
-  const [errorMessage, setErrorMessage] = useState('');
-
-  //임시 코드 - 생성 버튼 클릭 시 API 연결
-  const handleSubmit = () => {
-    console.log('Name:', name);
-    console.log('Goal Message:', goalMessage);
-    console.log('Goal Time:', parsedGoalTime); //parsedGoalTime 이 Int형입니당~
-  };
-
-  const handleGoalTimeChange = (text: string) => {
-    const parsedValue = parseInt(text, 10);
-    if (isNaN(parsedValue) || text.length > 4) {
-      setErrorMessage('시간은 4자리 이내의 숫자만 입력할 수 있습니다.');
-      setGoalTime('');
-    } else {
-      setErrorMessage('');
-      setGoalTime(text);
-      setParsedGoalTime(parsedValue);
-    }
-  };
-
-  const isFormValid =
-    name.trim() !== '' &&
-    goalMessage.trim() !== '' &&
-    !isNaN(parseInt(goalTime)) &&
-    parseInt(goalTime) >= 0;
+const CreateStudyForm = () => {
+  const {
+    name,
+    setName,
+    goalMessage,
+    setGoalMessage,
+    goalTime,
+    handleGoalTimeChange,
+    errorMessage,
+    isFormValid,
+    handleSubmit,
+  } = useCreateStudyForm();
 
   return (
     <VStack style={CreateStudyFormStyles.fullContainer}>

--- a/src/components/Profile/ProfileName/index.tsx
+++ b/src/components/Profile/ProfileName/index.tsx
@@ -12,7 +12,7 @@ const ProfileName: React.FC<UsersProps> = ({member: user}) => {
         <Text size="xs" bold={true} style={ProfileNameStyles.nickNameStyle}>
           {user.mainTitle}
         </Text>
-        <Heading>{user.mainTitle}</Heading>
+        <Heading>{user.name}</Heading>
       </HStack>
     </>
   );

--- a/src/components/types/StudyDetailType/StudyDetailType.ts
+++ b/src/components/types/StudyDetailType/StudyDetailType.ts
@@ -1,5 +1,5 @@
 import {Participant, StudyDetail} from '@/src/api/study/types';
-
+import {RouteProp} from '@react-navigation/native';
 export type StudyDetailHeaderProps = {
   studyDetail: StudyDetail;
 };
@@ -16,3 +16,8 @@ export type StudyMemberProps = {
 export type StudyMemberListProps = {
   participants: Participant[];
 };
+
+export type StudyDetailScreenRouteProp = RouteProp<
+  {StudyDetail: {studyId: number}},
+  'StudyDetail'
+>;

--- a/src/hooks/useCreateStudy.ts
+++ b/src/hooks/useCreateStudy.ts
@@ -1,0 +1,17 @@
+import {useMutation} from '@tanstack/react-query';
+import {useRecoilValue} from 'recoil';
+import authState from '@/src/recoil/authAtom';
+import {CreateStudyRequest} from '../api/study/types';
+import {createStudy} from '../api/study/studies/createStudy';
+
+export const useCreateStudy = () => {
+  const auth = useRecoilValue(authState);
+  return useMutation<{inviteCode: string}, Error, CreateStudyRequest>({
+    mutationFn: (newStudy: CreateStudyRequest) =>
+      createStudy(newStudy, auth.authToken),
+    onSuccess: data => {
+      console.log('Invite Code:', data.inviteCode);
+      //Invite Code를 보여주는 모달로 Params와 같이 Navigate 하면 될 것 같아용
+    },
+  });
+};

--- a/src/hooks/useCreateStudyForm.ts
+++ b/src/hooks/useCreateStudyForm.ts
@@ -1,0 +1,53 @@
+import {useState} from 'react';
+import {useCreateStudy} from './useCreateStudy';
+
+export const useCreateStudyForm = () => {
+  const [name, setName] = useState('');
+  const [goalMessage, setGoalMessage] = useState('');
+  const [goalTime, setGoalTime] = useState('');
+  const [parsedGoalTime, setParsedGoalTime] = useState(0);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const {mutate: createStudyMutate} = useCreateStudy();
+
+  const handleGoalTimeChange = (text: string) => {
+    const parsedValue = parseInt(text, 10);
+    if (isNaN(parsedValue) || text.length > 4) {
+      setErrorMessage('시간은 4자리 이내의 숫자만 입력할 수 있습니다.');
+      setGoalTime('');
+    } else {
+      setErrorMessage('');
+      setGoalTime(text);
+      setParsedGoalTime(parsedValue);
+    }
+  };
+
+  const isFormValid =
+    name.trim() !== '' &&
+    goalMessage.trim() !== '' &&
+    !isNaN(parseInt(goalTime, 10)) &&
+    parseInt(goalTime, 10) >= 0;
+
+  const handleSubmit = () => {
+    if (!isFormValid) {
+      return;
+    }
+    createStudyMutate({
+      name,
+      goalMessage,
+      goalTime: parsedGoalTime,
+    });
+  };
+
+  return {
+    name,
+    setName,
+    goalMessage,
+    setGoalMessage,
+    goalTime,
+    handleGoalTimeChange,
+    errorMessage,
+    isFormValid,
+    handleSubmit,
+  };
+};

--- a/src/screens/StudyDetailScreen/index.tsx
+++ b/src/screens/StudyDetailScreen/index.tsx
@@ -8,16 +8,12 @@ import {Box} from '@/components/ui/box';
 import {SafeAreaView} from '@/components/ui/safe-area-view';
 import {ScrollView} from '@/components/ui/scroll-view';
 import StudyMemberList from '@/src/components/StudyDetail/StudyMemberList';
-import {RouteProp, useRoute} from '@react-navigation/native';
+import {useRoute} from '@react-navigation/native';
 import {useStudyDetail} from '@/src/hooks/useStudyDetail';
 import {useStudyParticipants} from '@/src/hooks/useStudyParticipants';
 import Loader from '@/src/components/Loader';
 import {Text} from '@/components/ui';
-
-type StudyDetailScreenRouteProp = RouteProp<
-  {StudyDetail: {studyId: number}},
-  'StudyDetail'
->;
+import {StudyDetailScreenRouteProp} from '@/src/components/types/StudyDetailType/StudyDetailType';
 
 const StudyDetailScreen = () => {
   const route = useRoute<StudyDetailScreenRouteProp>();


### PR DESCRIPTION
## 💡 Issue number #67 

[issue_67](https://github.com/su-yeong-ice-pork/front-end/issues/67)

## 🚀 Description

스터디 방 생성 API 구현

- [x] tanstack query
- [x] 비지니스 로직 분리


## 💻 etc.

StudyDetailScreen Type 이동했습니다.
ProfileHeader에서 이름에 칭호 나오는 것 수정했습니다.
커스텀 훅에서 API 로직과 UI 사용되는 로직을 분리해서 두 개의 파일을 만들었는데 디렉토리 구조 없이 놔두니까 정신 없어보이네요..
hooks에서 스크린별로 디렉토리를 만들어두는게 좋을지 아니면 각 screens에 hooks 디렉토리를 생성하는게 좋을지 같이 정해보면 좋을 듯 합니다 !

close #67 