### PR TITLE
[Feature] 기록 랭킹 API 구현

### DIFF
--- a/src/api/rankings/individual.ts
+++ b/src/api/rankings/individual.ts
@@ -1,0 +1,23 @@
+import apiClient from '@/src/api/axiosInstance';
+import {IndividualRanking, GetIndividualRankingResponse} from './types';
+
+/**
+ * 개인 랭킹 조회 API
+ * GET: /ranks/individual
+ */
+export const fetchIndividualRanking = async (
+  authToken: string,
+): Promise<{date: string; ranking: IndividualRanking[]}> => {
+  const response = await apiClient.get<GetIndividualRankingResponse>(
+    '/ranks/individual',
+    {
+      headers: {Authorization: authToken},
+    },
+  );
+  if (!response.data.success) {
+    throw new Error(
+      response.data.error || '개인 랭킹 데이터를 불러오는데 실패했습니다.',
+    );
+  }
+  return response.data.response;
+};

--- a/src/api/rankings/studies.ts
+++ b/src/api/rankings/studies.ts
@@ -1,0 +1,23 @@
+import apiClient from '@/src/api/axiosInstance';
+import {GroupRanking, GetGroupRankingResponse} from './types';
+
+/**
+ * 그룹 랭킹 조회 API
+ * GET: /ranks/studies
+ */
+export const fetchGroupRanking = async (
+  authToken: string,
+): Promise<{date: string; ranking: GroupRanking[]}> => {
+  const response = await apiClient.get<GetGroupRankingResponse>(
+    '/ranks/studies',
+    {
+      headers: {Authorization: authToken},
+    },
+  );
+  if (!response.data.success) {
+    throw new Error(
+      response.data.error || '그룹 랭킹 데이터를 불러오는데 실패했습니다.',
+    );
+  }
+  return response.data.response;
+};

--- a/src/api/rankings/types.ts
+++ b/src/api/rankings/types.ts
@@ -1,0 +1,33 @@
+export type IndividualRanking = {
+  rank: number;
+  memberId: number;
+  name: string;
+  profileImage: string;
+  totalStudyTime: string;
+  grassScore: number;
+};
+
+export type GetIndividualRankingResponse = {
+  success: boolean;
+  response: {
+    date: string;
+    ranking: IndividualRanking[];
+  };
+  error: string | null;
+};
+
+export type GroupRanking = {
+  rank: number;
+  studyName: string;
+  memberCount: number;
+  totalStudyTime: string;
+};
+
+export type GetGroupRankingResponse = {
+  success: boolean;
+  response: {
+    date: string;
+    ranking: GroupRanking[];
+  };
+  error: string | null;
+};

--- a/src/components/StudyRecord/RankingSection/RankingList/GroupRankingList/index.tsx
+++ b/src/components/StudyRecord/RankingSection/RankingList/GroupRankingList/index.tsx
@@ -4,8 +4,9 @@ import {Box, HStack, Text, VStack} from '@/components/ui';
 import {RankingListStyles} from '../RankingListStyles.ts';
 import {LIST_TEXT} from '@/src/constants/Ranking/Ranking.ts';
 import {ICONS} from '@/src/constants/image/icons.ts';
+import {GroupRankingListProps} from '@/src/components/types/RankingType/RankingSectionType.ts';
 
-const GroupRankingList = ({rankingData}) => {
+const GroupRankingList: React.FC<GroupRankingListProps> = ({rankingData}) => {
   return (
     <ScrollView style={RankingListStyles.container}>
       {rankingData.map((item, index) => (

--- a/src/components/StudyRecord/RankingSection/RankingList/IndividualRankingList/index.tsx
+++ b/src/components/StudyRecord/RankingSection/RankingList/IndividualRankingList/index.tsx
@@ -3,8 +3,11 @@ import {Image, ScrollView} from 'react-native';
 import {Box, HStack, Text, VStack} from '@/components/ui';
 import {RankingListStyles} from '../RankingListStyles.ts';
 import {LIST_TEXT} from '@/src/constants/Ranking/Ranking.ts';
+import {IndividualRankingListProps} from '@/src/components/types/RankingType/RankingSectionType.ts';
 
-const IndividualRankingList = ({rankingData}) => {
+const IndividualRankingList: React.FC<IndividualRankingListProps> = ({
+  rankingData,
+}) => {
   return (
     <ScrollView style={RankingListStyles.container}>
       {rankingData.map((item, index) => (
@@ -23,21 +26,17 @@ const IndividualRankingList = ({rankingData}) => {
             style={RankingListStyles.profileImage}
           />
           <VStack>
-            <Text style={RankingListStyles.nameText}>
-              {item.name}
-            </Text>
+            <Text style={RankingListStyles.nameText}>{item.name}</Text>
             <HStack>
               <Text style={RankingListStyles.titleText}>
-                {LIST_TEXT.TODAY_TOTAL_TIME}
+                {LIST_TEXT.TOTAL_TIME}
               </Text>
               <Text style={RankingListStyles.scoreText}>
                 {`${item.totalStudyTime}`}
               </Text>
             </HStack>
             <HStack>
-              <Text style={RankingListStyles.titleText}>
-                {LIST_TEXT.SCORE}
-              </Text>
+              <Text style={RankingListStyles.titleText}>{LIST_TEXT.SCORE}</Text>
               <Text style={RankingListStyles.scoreText}>
                 {` ${item.grassScore}`}
               </Text>

--- a/src/components/types/RankingType/RankingSectionType.ts
+++ b/src/components/types/RankingType/RankingSectionType.ts
@@ -1,0 +1,43 @@
+export type RankingData = {
+  date: string;
+};
+
+export type UseRankingSectionFormReturn = {
+  rankingType: 'individual' | 'group';
+  toggleRanking: () => void;
+  month: string;
+  day: string;
+};
+
+export type IndividualRanking = {
+  rank: number;
+  memberId: number;
+  name: string;
+  profileImage: string | null;
+  totalStudyTime: string;
+  grassScore: number;
+};
+
+export type GroupRanking = {
+  rank: number;
+  studyName: string;
+  memberCount: number;
+  totalStudyTime: string;
+};
+
+export type IndividualRankingData = {
+  date: string;
+  ranking: IndividualRanking[];
+};
+export type GroupRankingData = {
+  date: string;
+  ranking: GroupRanking[];
+};
+
+export type IndividualRankingListProps = {
+  rankingData: IndividualRanking[];
+};
+
+export type GroupRankingListProps = {
+  rankingData: GroupRanking[];
+};

--- a/src/hooks/rankings/useGroupRanking.ts
+++ b/src/hooks/rankings/useGroupRanking.ts
@@ -1,0 +1,14 @@
+import {useQuery} from '@tanstack/react-query';
+import {useRecoilValue} from 'recoil';
+import authState from '@/src/recoil/authAtom';
+import {fetchGroupRanking} from '@/src/api/rankings/studies';
+import {GroupRanking} from '@/src/api/rankings/types';
+
+export const useGroupRanking = () => {
+  const auth = useRecoilValue(authState);
+  return useQuery<{date: string; ranking: GroupRanking[]}, Error>({
+    queryKey: ['groupRanking'],
+    queryFn: () => fetchGroupRanking(auth.authToken),
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/rankings/useIndividualRanking.ts
+++ b/src/hooks/rankings/useIndividualRanking.ts
@@ -1,0 +1,13 @@
+import {useQuery} from '@tanstack/react-query';
+import {useRecoilValue} from 'recoil';
+import authState from '@/src/recoil/authAtom';
+import {fetchIndividualRanking} from '@/src/api/rankings/individual';
+import {IndividualRanking} from '@/src/api/rankings/types';
+
+export const useIndividualRanking = () => {
+  const auth = useRecoilValue(authState);
+  return useQuery<{date: string; ranking: IndividualRanking[]}, Error>({
+    queryKey: ['individualRanking'],
+    queryFn: () => fetchIndividualRanking(auth.authToken),
+  });
+};

--- a/src/hooks/rankings/useRankingSection.ts
+++ b/src/hooks/rankings/useRankingSection.ts
@@ -1,0 +1,31 @@
+import {useState, useMemo} from 'react';
+import {
+  RankingData,
+  UseRankingSectionFormReturn,
+} from '@/src/components/types/RankingType/RankingSectionType';
+
+export const useRankingSectionForm = (
+  individualData?: RankingData,
+  groupData?: RankingData,
+): UseRankingSectionFormReturn => {
+  const [rankingType, setRankingType] = useState<'individual' | 'group'>(
+    'individual',
+  );
+
+  const toggleRanking = () => {
+    setRankingType(prev => (prev === 'individual' ? 'group' : 'individual'));
+  };
+
+  const date =
+    rankingType === 'individual' ? individualData?.date : groupData?.date;
+
+  const {month, day} = useMemo(() => {
+    if (date) {
+      const [m, d] = date.split(/월|일/).filter(Boolean);
+      return {month: m, day: d};
+    }
+    return {month: '', day: ''};
+  }, [date]);
+
+  return {rankingType, toggleRanking, month, day};
+};


### PR DESCRIPTION
## 💡 Issue number #76 

[issue_76](https://github.com/su-yeong-ice-pork/front-end/issues/76)

## 🚀 Description

- [x] tanstack-query 구현
- [x] API 및 커스텀 훅 구현

## 💻 etc.

랭킹섹션 컴포넌트 부분 props type 설정이 안된 부분은 수정하였습니다 !
API 리스트에는 학과 랭킹이 존재하는데 UI에 없어서 아직 연결을 안했습니다 @won0104 

나머지 부분은 컴포넌트가 워낙 잘 짜여져있어서 수월하게 했습니다 감사합니당
잘못되거나 통일 처리 할 부분 있으면 코멘트 남겨주세요 ~!!

close #76 