### PR TITLE
[REFACOTR] CreateStudyScreen 스크롤 BUG 수정 

### DIFF
--- a/src/components/CreateStudyForm/CreateStudyFormStyles.ts
+++ b/src/components/CreateStudyForm/CreateStudyFormStyles.ts
@@ -6,8 +6,8 @@ const {height} = Dimensions.get('window');
 export const CreateStudyFormStyles = StyleSheet.create({
   fullContainer: {
     width: '100%',
-    height: '100%',
     backgroundColor: '#1B9DC1',
+    paddingBottom: height * 0.2,
   },
 
   inputContainer: {

--- a/src/screens/CreateStudyScreen/CreateStudyScreenStyles.ts
+++ b/src/screens/CreateStudyScreen/CreateStudyScreenStyles.ts
@@ -6,4 +6,7 @@ export const CreateStudyScreenStyles = StyleSheet.create({
     flex: 1,
     backgroundColor: COLOR.BACK_GROUND,
   },
+  scrollView: {
+    flexGrow: 1,
+  },
 });

--- a/src/screens/CreateStudyScreen/index.tsx
+++ b/src/screens/CreateStudyScreen/index.tsx
@@ -10,9 +10,9 @@ import CreateStudyForm from '@/src/components/CreateStudyForm';
 const CreateStudyScreen = ({}) => {
   return (
     <SafeAreaView style={CreateStudyScreenStyles.safeArea}>
-      <ScrollView>
       <Header Title={TITLE} />
-      <CreateStudyForm/>
+      <ScrollView style={CreateStudyScreenStyles.scrollView}>
+        <CreateStudyForm />
       </ScrollView>
       <BottomBar />
     </SafeAreaView>


### PR DESCRIPTION
## 💡 Issue number (ex. #1000)
#82 
## 🚀 Description
확인해보니까 다른 부분에서는 문제가 없었는데 화면 길이가 짧아지면 밑에 padding이 같이 짧아져서 바텀 바에 가려서 발생하는 문제더라구요! 해결했습니당~   

## 💻 etc.
화면이 짧아져서 스터디 생성 버튼이 겹치는 상황도 생기더군용.. 
근데 이게 다른 화면에선 충분히 높아서 더 높이자니 다른 화면들이 이상해져서 고민중입니당,, 
(근데 요즘 이렇게 세로가 짧은 폰이 없어서 괜찮을 것 같기도 해요~)

또 오류 나오면 말씀해주세용!!